### PR TITLE
Add context menu for note

### DIFF
--- a/app/src/main/java/com/example/notes/data/note/adapter/NoteAdapter.java
+++ b/app/src/main/java/com/example/notes/data/note/adapter/NoteAdapter.java
@@ -33,14 +33,6 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteViewHolder> {
         return notes.size();
     }
 
-    public void addItem(int position) {
-        notifyItemInserted(position);
-    }
-
-    public void modifyItem(int position) {
-        notifyItemChanged(position);
-    }
-
     public void deleteItem(int position) {
         notifyItemRemoved(position);
     }

--- a/app/src/main/java/com/example/notes/data/note/adapter/NoteAdapter.java
+++ b/app/src/main/java/com/example/notes/data/note/adapter/NoteAdapter.java
@@ -33,6 +33,18 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteViewHolder> {
         return notes.size();
     }
 
+    public void addItem(int position) {
+        notifyItemInserted(position);
+    }
+
+    public void modifyItem(int position) {
+        notifyItemChanged(position);
+    }
+
+    public void deleteItem(int position) {
+        notifyItemRemoved(position);
+    }
+
     public void setNotes(ArrayList<Note> newNotes) {
         this.notes.clear();
         this.notes.addAll(newNotes);
@@ -44,6 +56,7 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteViewHolder> {
     }
 
     public interface OnClickNoteListener {
-        void onClickNote(Note note);
+        void onEditNote(Note note, int position);
+        void onDeleteNote(Note note, int position);
     }
 }

--- a/app/src/main/java/com/example/notes/data/note/adapter/NoteViewHolder.java
+++ b/app/src/main/java/com/example/notes/data/note/adapter/NoteViewHolder.java
@@ -1,20 +1,27 @@
 package com.example.notes.data.note.adapter;
 
+import android.view.MenuItem;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.PopupMenu;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.notes.R;
 import com.example.notes.data.note.Note;
 
-public class NoteViewHolder extends RecyclerView.ViewHolder {
+public class NoteViewHolder extends RecyclerView.ViewHolder implements PopupMenu.OnMenuItemClickListener {
     private final TextView tvTitle;
     private final TextView tvDescription;
     private final TextView tvImportant;
     private final TextView tvDate;
+    private final ImageView noteMenu;
     private Note note;
+
+    private final PopupMenu popupMenu;
+    private final NoteAdapter.OnClickNoteListener onClickNoteListener;
 
     public NoteViewHolder(@NonNull View itemView, NoteAdapter.OnClickNoteListener onClickNoteListener) {
         super(itemView);
@@ -22,8 +29,15 @@ public class NoteViewHolder extends RecyclerView.ViewHolder {
         tvDescription = itemView.findViewById(R.id.note_description);
         tvImportant = itemView.findViewById(R.id.note_important);
         tvDate = itemView.findViewById(R.id.note_date);
+        noteMenu = itemView.findViewById(R.id.note_menu);
+        this.onClickNoteListener = onClickNoteListener;
 
-        itemView.setOnClickListener(view -> onClickNoteListener.onClickNote(this.note));
+        popupMenu = new PopupMenu(itemView.getContext(), noteMenu);
+        popupMenu.inflate(R.menu.note_context_menu);
+
+        popupMenu.setOnMenuItemClickListener(this);
+
+        noteMenu.setOnClickListener(v -> popupMenu.show());
     }
 
     public void bind(Note note) {
@@ -37,5 +51,21 @@ public class NoteViewHolder extends RecyclerView.ViewHolder {
 
         String date = "Date: " + note.getDate();
         tvDate.setText(date);
+    }
+
+    @Override
+    public boolean onMenuItemClick(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.note_menu_modify:
+                onClickNoteListener.onEditNote(this.note, getAdapterPosition());
+                return true;
+
+            case R.id.note_menu_delete:
+                onClickNoteListener.onDeleteNote(this.note, getAdapterPosition());
+                return true;
+
+            default:
+                return false;
+        }
     }
 }

--- a/app/src/main/java/com/example/notes/ui/MainActivity.java
+++ b/app/src/main/java/com/example/notes/ui/MainActivity.java
@@ -26,7 +26,9 @@ public class MainActivity extends AppCompatActivity implements NoteListFragment.
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        initListNoteFragment();
+        if (savedInstanceState == null) {
+            initListNoteFragment();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/notes/ui/note/NoteListFragment.java
+++ b/app/src/main/java/com/example/notes/ui/note/NoteListFragment.java
@@ -61,8 +61,14 @@ public class NoteListFragment extends Fragment implements NoteAdapter.OnClickNot
     }
 
     @Override
-    public void onClickNote(Note note) {
-        this.controller.onNoteClicked(note);
+    public void onEditNote(Note note, int position) {
+        controller.onNoteClicked(note);
+    }
+
+    @Override
+    public void onDeleteNote(Note note, int position) {
+        repository.delete(note.getId());
+        adapter.deleteItem(position);
     }
 
     public interface NoteListController {

--- a/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_more_vert_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/layout/note_item.xml
+++ b/app/src/main/res/layout/note_item.xml
@@ -6,10 +6,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     app:cardElevation="@dimen/note_item_card_elevation"
     app:cardCornerRadius="@dimen/note_item_card_corner_radius"
-    android:layout_margin="@dimen/note_item_margin"
-    android:clickable="true"
-    android:focusable="true"
-    android:background="?selectableItemBackground">
+    android:layout_margin="@dimen/note_item_margin" >
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -53,9 +50,23 @@
             android:layout_gravity="end"
             android:layout_marginTop="@dimen/note_item_margin"
             android:textSize="@dimen/note_item_label_text_size"
-            app:layout_constraintTop_toBottomOf="@id/note_description"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/note_important"
+            app:layout_constraintStart_toStartOf="parent"
             tools:text="@string/date" />
+
+        <ImageView
+            android:id="@+id/note_menu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_baseline_more_vert_24"
+            android:layout_marginEnd="@dimen/note_item_margin"
+            android:contentDescription="@string/note_img_view_desc"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?selectableItemBackground"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/menu/note_context_menu.xml
+++ b/app/src/main/res/menu/note_context_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/note_menu_modify"
+        android:title="@string/modify"/>
+
+    <item
+        android:id="@+id/note_menu_delete"
+        android:title="@string/delete"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="date">Date:</string>
     <string name="select_date">Select Date</string>
     <string name="agree">Agree</string>
+    <string name="modify">Modify</string>
+    <string name="delete">Delete</string>
+    <string name="note_img_view_desc">Note actions</string>
 </resources>


### PR DESCRIPTION
1, 2 и 4 задания были уже сделаны в предыдущем дз. (см. последний скриншот)
Здесь добавлено меню и обработка нажатий на его элементы
Теперь переход на фрагмент создания/изменения заметки происходит не по нажатия на саму заметку, а по нажатию на элемент Modify в меню.
Добавлено удаление заметки - также через меню
![Screenshot_1642433439](https://user-images.githubusercontent.com/95960288/149798956-0d7788e6-61c8-46c3-ae46-30b1ae037b42.png)
![Screenshot_1642433467](https://user-images.githubusercontent.com/95960288/149798976-86ccce98-1843-4070-80de-2a3b0c689c41.png)
![Screenshot_1642433471](https://user-images.githubusercontent.com/95960288/149798991-b8eade83-8d3d-45d3-af67-5c3c7da9b9f8.png)
![Screenshot_1642433472](https://user-images.githubusercontent.com/95960288/149799019-2fe0f341-3ab8-47fa-ad0b-0a1009b57c26.png)
![Screenshot_1642433488](https://user-images.githubusercontent.com/95960288/149799025-55804a49-ebee-4a67-a8d0-d2333f3d1a26.png)
![Screenshot_1642433514](https://user-images.githubusercontent.com/95960288/149799088-87dc708b-28ee-4576-870b-b33ca45d5ac3.png)

